### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ csv = "1"
 derive_builder = "0.10"
 getset = "0.1"
 log = "0.4"
-prettytable-rs = "0.8"
+prettytable-rs = "0.9"
 pretty_assertions = "1"
 rslua = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 thiserror = "1"
-chrono = { version = "0.4", features = ["serde"]}
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std"]}
 tokio = { version = "1", features = ["full"] }
 tokio-serde-json = "0.3"
 url = "2"


### PR DESCRIPTION
term 0.5.2 is vulnerable to RUSTSEC-2018-0015.
time 0.1.44 is vulnerable to CVE-2020-26235 and RUSTSEC-2020-0071.

Before this commit:

time v0.1.44
└── chrono v0.4.22
    └── wrk-api-bench v0.0.7

term v0.5.2
└── prettytable-rs v0.8.0
    └── wrk-api-bench v0.0.7